### PR TITLE
Fix find_library add_library_mapping signature

### DIFF
--- a/src/BinDeps.jl
+++ b/src/BinDeps.jl
@@ -27,7 +27,7 @@ module BinDeps
     function find_library(pkg,libname,filename)
         dl = dlopen_e(joinpath(Pkg.dir(),pkg,"deps","usr","lib",filename))
         if dl != C_NULL
-            ccall(:add_library_mapping,Int32,(Ptr{Uint8},Ptr{Uint8}),libname,dl)
+            ccall(:add_library_mapping,Cint,(Ptr{Cchar},Ptr{Void}),libname,dl)
         else
             dl = dlopen_e(libname)
         end


### PR DESCRIPTION
In my tests `add_library_mapping` was not working properly until I changed the signature to match the one in Julia's `ccall.cpp`.
