### PR TITLE
Fix delete! usage so that BinDeps works on all v0.2-pre versions of julia

### DIFF
--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -264,7 +264,8 @@ function generate_steps(dep::LibraryDependency, h::Autotools,  provider_opts)
 	merge!(opts,h.opts)
 	if haskey(opts,:installed_libname)
 		!haskey(opts,:installed_libpath) || error("Can't specify both installed_libpath and installed_libname")
-		opts[:installed_libpath] = ByteString[joinpath(libdir(dep),delete!(opts,:installed_libname))]
+		opts[:installed_libpath] = ByteString[joinpath(libdir(dep),opts[:installed_libname])]
+		delete!(opts, :installed_libname)
 	elseif !haskey(opts,:installed_libpath)
 		opts[:installed_libpath] = ByteString[joinpath(libdir(dep),x)*"."*shlib_ext for x in get(dep.properties,:aliases,ByteString[])]
 	end
@@ -281,7 +282,8 @@ function generate_steps(dep::LibraryDependency, h::Autotools,  provider_opts)
 		opts[:rpath_dirs] = String[]
 	end
 	if haskey(opts,:configure_subdir)
-		opts[:srcdir] = joinpath(opts[:srcdir],delete!(opts,:configure_subdir))
+		opts[:srcdir] = joinpath(opts[:srcdir],opts[:configure_subdir])
+		delete!(opts, :configure_subdir)
 	end
 	unshift!(opts[:include_dirs],includedir(dep))
 	unshift!(opts[:lib_dirs],libdir(dep))


### PR DESCRIPTION
BinDeps will break after https://github.com/JuliaLang/julia/commit/e421dc3ea7fab020d5c87fcddabfe619bebf7c3e without this change, so it would be good to apply and update METADATA asap.  It will still work with older versions with this change.
