### PR TITLE
enable homebrew install on mac

### DIFF
--- a/src/BinDeps.jl
+++ b/src/BinDeps.jl
@@ -465,8 +465,8 @@ module BinDeps
 
     function cacheHomebrewPackages()
         empty!(installed_homebrew_packages)
-        for pkg in EachLine(read_from(`brew list`)[1])
-            add!(installed_homebrew_packages,chomp(pkg))
+        for pkg in EachLine(readsfrom(`brew list`)[1])
+            push!(installed_homebrew_packages,chomp(pkg))
         end
         installed_homebrew_packages
     end
@@ -483,7 +483,7 @@ module BinDeps
         if(isempty(installed_homebrew_packages))
             cacheHomebrewPackages()
         end
-        if(has(installed_homebrew_packages,x.name))
+        if(contains(installed_homebrew_packages,x.name))
             info("Package already installed")
         else
             run(`brew install $(x.desired_options) $(x.name)`)

--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -361,7 +361,7 @@ end
 
 # Default installation method
 if OS_NAME == :Darwin
-	defaults = [Binaries,BuildProcess]
+	defaults = [Binaries,PackageManager,BuildProcess]
 elseif OS_NAME == :Linux
 	defaults = [PackageManager,BuildProcess]
 elseif OS_NAME == :Windows


### PR DESCRIPTION
I noticed that the homebrew provider wasn't being used at all on OS X. Was this intentional? I fixed this and also updated some homebrew cruft. 
