### PR TITLE
Fix error thrown by test_success if curl/wget/fetch command not found

### DIFF
--- a/src/BinDeps.jl
+++ b/src/BinDeps.jl
@@ -45,9 +45,13 @@ module BinDeps
         global downloadcmd
         if downloadcmd === nothing
             for checkcmd in (:curl, :wget, :fetch)
-                if success(`$checkcmd --help`)
-                    downloadcmd = checkcmd
-                    break
+                try
+                    if success(`$checkcmd --help`)
+                        downloadcmd = checkcmd
+                        break
+                    end
+                catch
+                    continue # don't bail if one of these fails
                 end
             end
         end


### PR DESCRIPTION
Continue past exceptions when one of the get commands is not found.
Fixes this error:

```
INFO: Running build script for package Cairo
WARNING: An exception occured while building binary dependencies.
You may have to take manual steps to complete the installation, see the error message below.
To reattempt the installation, run Pkg.fixup("Cairo").

 in build at pkg.jl:259
ERROR: could not start process `curl --help`: no such file or directory (ENOENT)
 in test_success at process.jl:420
 in success at process.jl:428
 in download_cmd at /home/isaiah/.julia/BinDeps/src/BinDeps.jl:48
 in lower at /home/isaiah/.julia/BinDeps/src/BinDeps.jl:222
 in generate_steps at /home/isaiah/.julia/BinDeps/src/dependencies.jl:222
 in lower at /home/isaiah/.julia/BinDeps/src/dependencies.jl:155
 in include_from_node1 at loading.jl:95
 in anonymous at no file:262
 in cd at file.jl:25
 in cd at pkg/dir.jl:28
 in build at pkg.jl:259
 in __fixup at pkg.jl:311
 in _fixup at pkg.jl:338
 in _fixup#g153 at no file
 in _fixup#g152 at no file
 in _fixup#g151 at no file
 in _resolve at pkg.jl:249
 in anonymous at no file:167
 in cd at file.jl:25
 in cd at pkg/dir.jl:28
 in update at pkg.jl:131
at /home/isaiah/.julia/Cairo/deps/build.jl:222
```
