### PR TITLE
Add REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,0 +1,2 @@
+julia 0.2-
+URIParser


### PR DESCRIPTION
Without this, ~~IniFile~~ `URIParser` is uninstalled when `Pkg.checkout("BinDeps")` is run (assuming it wasn't added by hand), because the package manager doesn't know that it's a dependency of master.

cc: @StefanKarpinski
