### PR TITLE
Changed "yum -v" to "yum --version"

### DIFF
--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -97,7 +97,7 @@ pkg_name(a::AptGet) = a.package
 
 libdir(p::AptGet,dep) = "/usr/lib"
 
-const has_yum = try success(`yum -v`) catch e false end
+const has_yum = try success(`yum --version`) catch e false end
 type Yum <: PackageManager
 	package::String
 end


### PR DESCRIPTION
On Centos 6, at least, `yum -v` fails and returns 1.  `yum --version` works.
