### PR TITLE
Fix for this error:

### DIFF
--- a/src/BinDeps.jl
+++ b/src/BinDeps.jl
@@ -8,7 +8,7 @@ module BinDeps
     import Base.Sys.shlib_ext
 
     function find_library(pkg,libname,files)
-        Base.warn_once("BinDeps.find_library is deprecated, use Base.find_library instead."; depth=1)
+        Base.warn_once("BinDeps.find_library is deprecated, use Base.find_library instead.")
         dl = C_NULL
         for filename in files
             dl = dlopen_e(joinpath(Pkg.dir(),pkg,"deps","usr","lib",filename))


### PR DESCRIPTION
ERROR: function warn_once does not accept named arguments
warn_once has the following signature:
in utils.jl: function warn_once(msg::String...)
