### PR TITLE
Cache dependencies during install macro

### DIFF
--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -442,13 +442,37 @@ end
 
 execute(dep::LibraryDependency,method) = run(lower(generate_steps(dep,method)))
 
-macro install()
-	esc(quote
-		if bindeps_context.do_install
-			for d in bindeps_context.deps
-				BinDeps.satisfy!(d)
-			end
-		end	end)
+macro install (_libmaps)
+    libmaps = eval(_libmaps)
+    load_cache = gensym()
+    ret = Expr(:block)
+    push!(ret.args,
+        esc(quote
+                load_cache = Dict()
+                if bindeps_context.do_install
+                    for d in bindeps_context.deps
+                        BinDeps.satisfy!(d)
+                        lib = BinDeps._find_library(d)
+                        if lib != ""
+                            load_cache[d.name] = lib
+                        end
+                    end
+                end
+                depsfile = open(joinpath(splitdir(Base.source_path())[1],"deps.jl"), "w")
+                println(depsfile, "macro checked_lib(libname, path)
+    (dlopen_e(path) == C_NULL) && error(\"Unable to load \\n\\n\$libname (\$path)\\n\\nPlease re-run Pkg.build(package), and restart Julia.\")
+    quote const \$(esc(libname)) = \$path end
+end")
+                for libkey in keys($libmaps)
+                    ((cached = get(load_cache,string(libkey),nothing)) === nothing) && continue
+                    println(depsfile, "@checked_lib ", $libmaps[libkey], " \"", escape_string(cached), "\"")
+                end
+                close(depsfile)
+            end))
+    if !(typeof(libmaps) <: Associative)
+        warn("Incorrect mapping in BinDeps.@install call. No dependencies will be cached.")
+    end
+    ret
 end
 
 # Usage: @load_dependencies [file] [filter]


### PR DESCRIPTION
New usage:

```
@ BinDeps.install [:tk => :libtk, :tcl=>:libtcl]
```

Writes (to `deps/deps.jl`), e.g.:

```
const libtcl = "C:\\Users\\isaiah\\.julia\\RPMmd\\deps\\usr\\x86_64-w64-mingw32\\sys-root\\mingw\\bin\\tcl85"
const libtk = "C:\\Users\\isaiah\\.julia\\RPMmd\\deps\\usr\\x86_64-w64-mingw32\\sys-root\\mingw\\bin\\tk85"
```
