### PR TITLE
Print out messages stating what bindeps is about to try and do before sudoing

### DIFF
--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -206,6 +206,7 @@ function generate_steps(dep::LibraryDependency,h::AptGet,opts)
 			  "Please make any necessary adjustments manually (This might just be a version upgrade)")
 	end
 	@build_steps begin
+		println("Installing dependency $(h.package) via `sudo apt-get install $(h.package)`:")
 		`sudo apt-get install $(h.package)`
 		()->(ccall(:jl_read_sonames,Void,()))
 	end
@@ -215,7 +216,12 @@ function generate_steps(dep::LibraryDependency,h::Yum,opts)
 		error("Will not force yum to rebuild dependency \"$(dep.name)\".\n"*
 		  	  "Please make any necessary adjustments manually (This might just be a version upgrade)")
 	end
-	`sudo yum install $(h.package)`
+	
+	@build_steps begin
+		println("Installing dependency $(h.package) via `sudo yum install $(h.package)`:")
+		`sudo yum install $(h.package)`
+		()->(ccall(:jl_read_sonames,Void,()))
+	end
 end
 function generate_steps(dep::LibraryDependency,h::NetworkSource,opts)
 	localfile = joinpath(downloadsdir(dep),basename(h.uri.path))


### PR DESCRIPTION
Closes #66 

Also adds in the call to `jl_read_sonames()` on `yum`-based systems, because those systems were lonely.
