### PR TITLE
make lib32/lib64 use WORD_SIZE, and apply on Windows too

### DIFF
--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -338,14 +338,9 @@ function _find_library(dep::LibraryDependency)
         push!(paths,libdir(p,dep))
 
         # Many linux distributions use lib32/lib64 as well
-        @unix_only begin
-        	if isdir(libdir(p,dep)*"32")
-        		push!(paths, libdir(p,dep)*"32")
-        	end
-        	if isdir(libdir(p,dep)*"64")
-        		push!(paths, libdir(p,dep)*"64")
-        	end
-    	end
+        if isdir(libdir(p,dep)*"$WORD_SIZE")
+        	push!(paths, libdir(p,dep)*"$WORD_SIZE")
+        end
         # Windows, do you know what `lib` stands for???
         @windows_only push!(paths,bindir(p,dep))
         (isempty(paths) || all(map(isempty,paths))) && continue


### PR DESCRIPTION
for windows binaries that we package ourselves, this will allow easier switching between 32 bit and 64 bit
