### PR TITLE
apt-cache, directory search fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,11 @@ There are also several builtin options. Some of them are:
  	This argument takes has the same syntax as the `os` keyword argument to \
 	`library_dependency`.
 
+ * `installed_libpath = "path"`
+
+ 	If the provider installs a library dependency to someplace other than the
+ 	standard search paths, that location can be specified here.
+
 # The high level interface - built in providers
 
 We have already seen the `AptGet`, and `Yum` providers, which all take a string naming the package as their data argument. The other build-in providers are:

--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -367,7 +367,7 @@ end
 
 #
 # Finds all copies of the library on the system, listed in preference order.
-# Return value is an array of tuples if the provider and the path where it is found
+# Return value is an array of tuples of the provider and the path where it is found
 #
 function _find_library(dep::LibraryDependency; provider = Any)
     ret = Any[]
@@ -378,7 +378,14 @@ function _find_library(dep::LibraryDependency; provider = Any)
     for (p,opts) in providers
         (p != nothing && can_use(typeof(p)) && can_provide(p,opts,dep)) || continue
         paths = String[]
+
+        # Allow user to override installation path
+        if haskey(opts,:installed_libpath) && isdir(opts[:installed_libpath])
+            unshift!(paths,opts[:installed_libpath])
+        end
+
         push!(paths,libdir(p,dep))
+
         if haskey(opts,:unpacked_dir) && isdir(joinpath(depsdir(dep),opts[:unpacked_dir]))
             push!(paths,joinpath(depsdir(dep),opts[:unpacked_dir]))
         end


### PR DESCRIPTION
- ~~`apt-cache showpkg` => `dpkg -s`.~~
  - ~~`apt-cache` can show a package even when it is not available (https://github.com/kmsquire/VideoIO.jl/pull/12#issuecomment-52018914)~~
- ~~add `/usr/lib/x86_64-linux-gnu`, `/usr/lib/i386-linux-gnu` to the default lib search path~~
  - ~~see the [Ubuntu Multiarch](https://wiki.ubuntu.com/MultiarchSpec)~~
- allow user to override the lib search path with `installed_libpath`.  
  - E.g., ffmpeg packages for Ubuntu are provided in a PPA, and install under `/opt/ffmpeg/lib`.
