### PR TITLE
Fix modern apt-cache parsing (fixes #91)

### DIFF
--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -110,7 +110,7 @@ end
 can_use(::Type{AptGet}) = has_apt && OS_NAME == :Linux
 package_available(p::AptGet) = can_use(AptGet) && !isempty(available_versions(p))
 function available_versions(p::AptGet)
-    vers = {}
+    vers = ASCIIString[]
     lookfor_version = false
     for l in eachline(`apt-cache showpkg $(p.package)`)
         if beginswith(l,"Version:")


### PR DESCRIPTION
As pointed out in #91, using `apt-cache` for checking installed versions is broken, although in ways that likely won't appear in automated testing.

Instead of checking if `apt-cache` has output, this PR attempts to parse all available versions of a package, and says that a package is available if there are any versions available.

Changes:
1. Added `DEBIAN_VERSION_REGEX`
2. Added `available_versions` (plural) function.  `available_version` gives a warning if there is more than one version available, and then returns the last element of the array returned by `available_versions` (is this necessary?)
3. Changed the return type of `available_version` from `VersionNumber` to `ASCIIString`, since there's no guarantee that the upstream version follows `SemVer` (e.g., from `Images.jl`, the upstream version of `libmagickwand5` is `6.7.7.10`)

Similar changes should probably be made to the Yum provider.
