### PR TITLE
Add `Pacman` to README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ defined the following dependencies:
 ```
 
 Let's suppose that these libraries are available in the `libfoo-dev` and `libbaz-dev`
-in apt-get and that both libraries are installed by the `libbaz` yum package. We may
+in apt-get and that both libraries are installed by the `libbaz` yum package and the `baz` pacman package. We may
 declare this as follows:
 
 ```julia
@@ -157,7 +157,7 @@ declare this as follows:
 		"libbaz-dev" => baz,
 	})
 	provides(Yum,"libbaz",[foo,baz])
-}
+	provides(Pacman,"baz",[foo,baz])
 ```
 
 One may remember the `provides` function by thinking `AptGet` `provides` the dependencies `foo` and `baz`. 
@@ -180,7 +180,7 @@ which is equivalent to (and in fact will be internally dispatched) to:
 ```
 
 If one provide satisfied multiple dependencies simultaneously, `dependency` may 
-also be an array of dependencies (as in the `Yum` case above). 
+also be an array of dependencies (as in the `Yum` and `Pacman` cases above). 
 
 There are also several builtin options. Some of them are:
 


### PR DESCRIPTION
Small change to the `README` file in order to advertise the `Pacman` provider. Should've been part of #101.
