### PR TITLE
Support "port" package manager (for OS X)

### DIFF
--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -849,17 +849,27 @@ macro install (_libmaps...)
 
                     # Generate "deps.jl" file for runtime loading
                     depsfile = open(joinpath(splitdir(Base.source_path())[1],"deps.jl"), "w")
+                    println(depsfile,
+                        """
+                        # This is an auto-generated file; do not edit
+                        """)
+                    println(depsfile, "# Pre-hooks")
                     println(depsfile, join(pre_hooks, "\n"))
                     println(depsfile,
                         """
+                        # Macro to load a library
                         macro checked_lib(libname, path)
                             (dlopen_e(path) == C_NULL) && error("Unable to load \\n\\n\$libname (\$path)\\n\\nPlease re-run Pkg.build(package), and restart Julia.")
                             quote const \$(esc(libname)) = \$path end
-                        end""")
+                        end
+                        """)
+                    println(depsfile, "# Load dependencies")
                     for libkey in keys($libmaps)
                         ((cached = get(load_cache,string(libkey),nothing)) === nothing) && continue
                         println(depsfile, "@checked_lib ", $libmaps[libkey], " \"", escape_string(cached), "\"")
                     end
+                    println(depsfile)
+                    println(depsfile, "# Load-hooks")
                     println(depsfile, join(load_hooks,"\n"))
                     close(depsfile)
                 end))


### PR DESCRIPTION
The MacPorts system for OS X uses "port" as package manager, similar to apt-get for Ubuntu. These changes add support for it to BinDeps.

Installing MacPorts is non-trivial, i.e. takes about half an hour following instructions on the MacPorts web site. Unlike HomeBrew, MacPorts also does not support installing packages into arbitrary directories. It behaves more like apt-get, except that MacPorts is not shipped with OS X by default.

I thus think that Julia should not be trying to automatically install MacPorts. Rather, BinDeps should detect whether it is available, and if so, use it. This is why support should be provided by BinDeps directly, rather than a separate package MacPorts.
