### PR TITLE
Only accept a single library for each name, and move SystemPath out of Binaries

### DIFF
--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -210,7 +210,7 @@ abstract Binaries <: DependencyProvider
 # indicates the library was found somewhere on the
 # system using dlopen.
 #
-immutable SystemPaths <: Binaries; end
+immutable SystemPaths <: DependencyProvider; end
 
 show(io::IO, ::SystemPaths) = print(io,"System Paths")
 
@@ -793,18 +793,22 @@ macro install (_libmaps...)
                                 if !isempty(libs)
                                     for dep in d.deps
                                         !BinDeps.applicable(dep) && continue
-                                        load_cache[dep.name] = libs[dep][2]
-                                        opts = libs[dep][1][2]
-                                        haskey(opts, :preload) && push!(pre_hooks,opts[:preload])
-                                        haskey(opts, :onload) && push!(load_hooks,opts[:onload])
+                                        if !haskey(load_cache, dep.name)
+                                            load_cache[dep.name] = libs[dep][2]
+                                            opts = libs[dep][1][2]
+                                            haskey(opts, :preload) && push!(pre_hooks,opts[:preload])
+                                            haskey(opts, :onload) && push!(load_hooks,opts[:onload])
+                                        end
                                     end
                                 end
                             else
                                 for (k,v) in libs
-                                    load_cache[d.name] = v
-                                    opts = k[2]
-                                    haskey(opts, :preload) && push!(pre_hooks,opts[:preload])
-                                    haskey(opts, :onload) && push!(load_hooks,opts[:onload])
+                                    if !haskey(load_cache, d.name)
+                                        load_cache[d.name] = v
+                                        opts = k[2]
+                                        haskey(opts, :preload) && push!(pre_hooks,opts[:preload])
+                                        haskey(opts, :onload) && push!(load_hooks,opts[:onload])
+                                    end
                                 end
                             end
                         end


### PR DESCRIPTION
Without this check in place, provider preferences were actually quite broken; the least preferred would get picked, and hooks would get mixed with library paths from other providers.  See https://github.com/staticfloat/homebrew-juliadeps/issues/38 for an example.

Moving SystemPath out of Binaries is necessary so that it is not included in `defaults` more than once, and so it has the proper ordering in preference