### PR TITLE
Fix for new Libdl module

### DIFF
--- a/src/BinDeps.jl
+++ b/src/BinDeps.jl
@@ -6,7 +6,13 @@ module BinDeps
             ChangeDirectory, FileDownloader, FileUnpacker, prepare_src,
             autotools_install, CreateDirectory, MakeTargets, SystemLibInstall
 
-    const dlext = isdefined(Base.Sys, :shlib_ext) ? Base.Sys.shlib_ext : Base.Sys.dlext # Julia 0.2/0.3 compatibility
+    if VERSION >= v"0.4.0-dev+3844"
+        import Base.Libdl: dlext, dlpath, RTLD_LAZY, DL_LOAD_PATH
+    else
+        const dlext = isdefined(Base.Sys, :shlib_ext) ? Base.Sys.shlib_ext : Base.Sys.dlext # Julia 0.2/0.3 compatibility
+        dlpath = Sys.dlpath
+        DL_LOAD_PATH = Base.DL_LOAD_PATH
+    end
     const shlib_ext = dlext # compatibility with older packages (e.g. ZMQ)
 
     function find_library(pkg,libname,files)

--- a/src/BinDeps.jl
+++ b/src/BinDeps.jl
@@ -88,7 +88,7 @@ module BinDeps
             elseif extension == ".zip"
                 return (`unzip -x $file -d $directory`)
             elseif extension == ".gz"
-                return (`mkdir $directory` |> `cp $file $directory` |> `gzip -dk $directory/$file`)
+                return (`mkdir $directory` |> `cp $file $directory` |> `gzip -d $directory/$file`)
             end
             error("I don't know how to unpack $file")
         end

--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -472,7 +472,7 @@ function _find_library(dep::LibraryDependency; provider = Any)
             if h != C_NULL
                 works = dep.libvalidate(l,h)
                 if VERSION >= v"0.3-"
-                    l = Sys.dlpath(h)
+                    l = dlpath(h)
                 end
                 dlclose(h)
                 if works
@@ -504,7 +504,7 @@ function _find_library(dep::LibraryDependency; provider = Any)
             # We don't want to use regular dlopen, because we want to get at
             # system libraries even if one of our providers is higher in the
             # DL_LOAD_PATH
-            for path in Base.DL_LOAD_PATH
+            for path in DL_LOAD_PATH
                 for ext in EXTENSIONS
                     opath = string(joinpath(path,lib),ext)
                     check_path!(ret,dep,opath)
@@ -537,7 +537,7 @@ if VERSION >= v"0.3-"
 
     function check_system_handle!(ret,dep,handle)
         if handle != C_NULL
-            libpath = Sys.dlpath(handle)
+            libpath = dlpath(handle)
             # Check that this is not a duplicate
             for p in ret
                 try


### PR DESCRIPTION
Also fix race condition in .gz extraction (6b69050cca9565d30f3a5d5f6d56e247b0022b36)

Please test this out, it works for me locally on both 0.3 and 0.4 (lots of deprecation warnings but those aren't time critical), but I am not aware of any packages using .gz archives to test the second commit here.
