### PR TITLE
use -f option to curl

### DIFF
--- a/src/BinDeps.jl
+++ b/src/BinDeps.jl
@@ -60,7 +60,7 @@ module BinDeps
         if downloadcmd == :wget
             return `wget -O $filename $url`
         elseif downloadcmd == :curl
-            return `curl -o $filename -L $url`
+            return `curl -f -o $filename -L $url`
         elseif downloadcmd == :fetch
             return `fetch -f $filename $url`
         elseif downloadcmd == :powershell


### PR DESCRIPTION
@jiahao I believe this is ultimately responsible for what happened in https://github.com/porterjamesj/Gumbo.jl/issues/13. Passing `-f`causes 22 to be returned rather than 0 in the case of 4xx or 5xx HTTP response codes, which seems more like what we want here.