### PR TITLE
Don't free() the handle after dlclose

### DIFF
--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -531,7 +531,6 @@ if VERSION >= v"0.3-"
         if err == 0
             check_system_handle!(ret,dep,handle)
             Libdl.dlclose(handle)
-            Libc.free(handle)
         end
     end
 


### PR DESCRIPTION
Of the possible code paths, there was only one that freed the `handle` after calling `dlclose`.  This change removes that `free()` statement, fixing an issue that was recently [brought to light](https://github.com/JuliaLang/julia/pull/10808#issuecomment-93126365) by JuliaLang/julia#10808.