### PR TITLE
silence another 0.4 warning

### DIFF
--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -825,7 +825,7 @@ macro install (_libmaps...)
                         """
                         # Macro to load a library
                         macro checked_lib(libname, path)
-                            ((VERSION >= v"0.4.0-dev+3844" ? Base.Libdl.dlopen_e : dlopen_e)(path) == C_NULL) && error("Unable to load \\n\\n\$libname (\$path)\\n\\nPlease re-run Pkg.build(package), and restart Julia.")
+                            ((VERSION >= v"0.4.0-dev+3844" ? Base.Libdl.dlopen_e : Base.dlopen_e)(path) == C_NULL) && error("Unable to load \\n\\n\$libname (\$path)\\n\\nPlease re-run Pkg.build(package), and restart Julia.")
                             quote const \$(esc(libname)) = \$path end
                         end
                         """)


### PR DESCRIPTION
Silences `Warning: both Libdl and Base export dlopen_e; uses of it in module XXXX must be qualified` warnings in recent 0.4 master.