### PR TITLE
Allow providing multiple package names as vector in provides()

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ defined the following dependencies:
 ```
 
 Let's suppose that these libraries are available in the `libfoo-dev` and `libbaz-dev`
-in apt-get and that both libraries are installed by the `libbaz` yum package and the `baz` pacman package. We may
+in apt-get and that both libraries are installed by the `baz` or the `baz1` yum package, and the `baz` pacman package. We may
 declare this as follows:
 
 ```julia
@@ -158,7 +158,7 @@ declare this as follows:
 		"libfoo-dev" => foo,
 		"libbaz-dev" => baz,
 	})
-	provides(Yum,"libbaz",[foo,baz])
+	provides(Yum,["baz","baz1"],[foo,baz])
 	provides(Pacman,"baz",[foo,baz])
 ```
 

--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -298,6 +298,12 @@ provider(::Type{Autotools},a::Autotools; opts...) = a
 provides(provider::DependencyProvider,dep::LibraryDependency; opts...) = push!(dep.providers,(provider,(Symbol=>Any)[k=>v for (k,v) in opts]))
 provides(helper::DependencyHelper,dep::LibraryDependency; opts...) = push!(dep.helpers,(helper,(Symbol=>Any)[k=>v for (k,v) in opts]))
 provides{T}(::Type{T},p,dep::LibraryDependency; opts...) = provides(provider(T,p; opts...),dep; opts...)
+function provides{T}(::Type{T},packages::AbstractArray,dep::LibraryDependency; opts...)
+    for p in packages
+        provides(T,p,dep; opts...)
+    end
+end
+
 function provides{T}(::Type{T},ps,deps::Vector{LibraryDependency}; opts...)
     p = provider(T,ps; opts...)
     for dep in deps


### PR DESCRIPTION
This is often needed to support several distributions.

I needed this this morning for GnuTLS.jl, and I realized it was missing from the docs. ~~You should know whether this actually does work when the line declares several libraries (here`[foo,baz]`), but I haven't actually tested this case.~~