### PR TITLE
Dead simple tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: julia
+os:
+  - linux
+julia:
+  - release
+  - nightly
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 BinDeps.jl
 ==========
 
+[![Build Status](https://travis-ci.org/JuliaLang/BinDeps.jl.svg?branch=master)](https://travis-ci.org/JuliaLang/BinDeps.jl)
+
 Easily build binary dependencies for Julia packages 
 
 # FAQ

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,4 @@
+Pkg.add("Cairo")  # Tests apt-get code paths
+using Cairo
+Pkg.add("HttpParser")  # Tests build-from-source code paths
+using HttpParser


### PR DESCRIPTION
I'm a bit of an interloper in BinDeps land, but I wanted to tag a new version with the fixes for recent deprecations but didn't feel confident doing so without tests. So here is a dead simple setup that just tries to install two packages that probably won't themselves break unless BinDeps itself is broken.

I see that https://github.com/JuliaLang/BinDeps.jl/pull/108 reached a similar conclusion, and I think it'd be great to do finer-grained testing, but I figured that this could be merged right away to get the ball rolling.