### PR TITLE
Fix for Unix which is not Linux

### DIFF
--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -433,9 +433,9 @@ function generate_steps(dep::LibraryDependency, h::Autotools,  provider_opts)
     steps
 end
 
+@unix_only const EXTENSIONS = ["",".so"]
 @osx_only const EXTENSIONS = ["",".dylib"]
 @windows_only const EXTENSIONS = ["", ".dll"]
-@linux_only const EXTENSIONS = ["",".so"]
 
 #
 # Finds all copies of the library on the system, listed in preference order.

--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -433,9 +433,7 @@ function generate_steps(dep::LibraryDependency, h::Autotools,  provider_opts)
     steps
 end
 
-@unix_only const EXTENSIONS = ["",".so"]
-@osx_only const EXTENSIONS = ["",".dylib"]
-@windows_only const EXTENSIONS = ["", ".dll"]
+const EXTENSIONS = ["", "." * Libdl.dlext]
 
 #
 # Finds all copies of the library on the system, listed in preference order.


### PR DESCRIPTION
On, for example, FreeBSD, BinDeps calls fail because "EXTENSIONS" is not set. I think this should fix it, at least for operating systems which Julia recognizes as "UNIX" (currently, just Linux and FreeBSD I think). 