### PR TITLE
Add Binaries installation method on linux

### DIFF
--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -548,7 +548,7 @@ end
 if OS_NAME == :Darwin
     defaults = [Binaries,PackageManager,SystemPaths,BuildProcess]
 elseif OS_NAME == :Linux
-    defaults = [PackageManager,SystemPaths,BuildProcess]
+    defaults = [Binaries, PackageManager,SystemPaths,BuildProcess]
 elseif OS_NAME == :Windows
     defaults = [Binaries,PackageManager,SystemPaths]
 else

--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -548,7 +548,7 @@ end
 if OS_NAME == :Darwin
     defaults = [Binaries,PackageManager,SystemPaths,BuildProcess]
 elseif OS_NAME == :Linux
-    defaults = [Binaries, PackageManager,SystemPaths,BuildProcess]
+    defaults = [PackageManager,SystemPaths,BuildProcess, Binaries]
 elseif OS_NAME == :Windows
     defaults = [Binaries,PackageManager,SystemPaths]
 else


### PR DESCRIPTION
I am not sure if there is any reason not to include `Binaries` method on linux but there are some packages do provide binary files for linux, like [Yeppp!](http://www.yeppp.info/). 
