### PR TITLE
Fix error in show(_, ::LibraryGroup)

### DIFF
--- a/src/debug.jl
+++ b/src/debug.jl
@@ -31,7 +31,7 @@ function show(io::IO, deps::LibraryGroup)
     print(io," - Library Group \"$(deps.name)\"")
     all = allf(deps)
     providers = satisfied_providers(deps,all)
-    if !(isempty(providers))
+    if providers != nothing && !(isempty(providers))
         print(io," (satisfied by ",join(providers,", "),")")
     end
     if !applicable(deps)


### PR DESCRIPTION
Fixes this error:
```jl
julia> @BinDeps.setup
library_dependency (generic function with 1 method)

julia> group = library_group("gtk")
 - Library Group "gtk"Error showing value of type BinDeps.LibraryGroup:
ERROR: MethodError: `start` has no method matching start(::Void)
 in isempty at iterator.jl:3
 in show at /home/tim/.julia/v0.4/BinDeps/src/debug.jl:34
 in anonymous at show.jl:1278
 in with_output_limit at ./show.jl:1255
 in showlimited at show.jl:1277
 in writemime at replutil.jl:4
 in display at REPL.jl:115
 in display at REPL.jl:118
 [inlined code] from multimedia.jl:151
 in display at multimedia.jl:162
 in print_response at REPL.jl:135
 in print_response at REPL.jl:122
 in anonymous at REPL.jl:624
 in anonymous at REPL.jl:827
 in anonymous at LineEdit.jl:767
 in prompt! at ./LineEdit.jl:1636
 in run_interface at ./LineEdit.jl:1605
 in run_frontend at ./REPL.jl:863
 in run_repl at ./REPL.jl:167
 in _start at ./client.jl:453
```
