### PR TITLE
Consider satisfy!ed if provided by SystemPaths

### DIFF
--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -719,7 +719,7 @@ function satisfy!(dep::LibraryDependency, methods = defaults)
     if !isempty(sp)
         for m in methods
             for s in sp
-                if s <: m
+                if s <: m || s <: SystemPaths
                     return s
                 end
             end


### PR DESCRIPTION
On some systems, `Pkg.build("Gtk")` invokes `sudo` even when all the necessary dependencies are already present. I've finally taken the time to track this down to `satisfied_providers`, for which I added a `@show dep viable_providers providers`. Here's an excerpt for the first few dependencies:

```
dep =  - Library "glib"
    - Satisfied by:
      - BinDeps.AptGet package libgtk-3-0 at /lib/x86_64-linux-gnu/libglib-2.0.so.0
    - Providers:
      - BinDeps.AptGet package libgtk-3-0
      - BinDeps.Yum package gtk3 (can't provide)

viable_providers = nothing
providers = Any[BinDeps.AptGet]    # viable_providers will get set to providers
dep =  - Library "gobject"
    - Satisfied by:
      - BinDeps.AptGet package libgtk-3-0 at /usr/lib/x86_64-linux-gnu/libgobject-2.0.so
    - Providers:
      - BinDeps.AptGet package libgtk-3-0
      - BinDeps.Yum package gtk3 (can't provide)

viable_providers = Any[BinDeps.AptGet]
providers = Any[BinDeps.AptGet]
dep =  - Library "gtk"
    - Satisfied by:
      - System Paths at /usr/lib/x86_64-linux-gnu/libgtk-3.so.0
    - Providers:
      - BinDeps.AptGet package libgtk-3-0
      - BinDeps.Yum package gtk3 (can't provide)

viable_providers = Any[BinDeps.AptGet]
providers = Any[BinDeps.SystemPaths]
```
Note providers on this last line is `SystemPaths`; the `intersect` in the [next block](https://github.com/JuliaLang/BinDeps.jl/blob/c34d70cbe3d31c87f81475a07c9cad1441d64df5/src/dependencies.jl#L613) will then result in there being no satisfied provider.

I'm not certain this PR puts the fix in the best place, but anyway it's a suggestion. CC @Keno, @vtjnash.
