### PR TITLE
Replace deprecated |> with pipeline(...) calls

### DIFF
--- a/src/BinDeps.jl
+++ b/src/BinDeps.jl
@@ -77,13 +77,13 @@ module BinDeps
             elseif (extension == ".bz2" && secondary_extension == ".tar") || extension == ".tbz"
                 return (`tar xjf $file --directory=$directory`)
             elseif extension == ".xz" && secondary_extension == ".tar"
-                return (`unxz -c $file `|>`tar xv --directory=$directory`)
+                return pipeline(`unxz -c $file `, `tar xv --directory=$directory`)
             elseif extension == ".tar"
                 return (`tar xf $file --directory=$directory`)
             elseif extension == ".zip"
                 return (`unzip -x $file -d $directory`)
             elseif extension == ".gz"
-                return (`mkdir $directory` |> `cp $file $directory` |> `gzip -d $directory/$file`)
+                return pipeline(`mkdir $directory`, `cp $file $directory`, `gzip -d $directory/$file`)
             end
             error("I don't know how to unpack $file")
         end
@@ -93,7 +93,7 @@ module BinDeps
         function unpack_cmd(file,directory,extension,secondary_extension)
             if((extension == ".gz" || extension == ".xz" || extension == ".bz2") && secondary_extension == ".tar") ||
                    extension == ".tgz" || extension == ".tbz"
-                return (`7z x $file -y -so`|>`7z x -si -y -ttar -o$directory`)
+                return pipeline(`7z x $file -y -so`, `7z x -si -y -ttar -o$directory`)
             elseif extension == ".zip" || extension == ".7z"
                 return (`7z x $file -y -o$directory`)
             end


### PR DESCRIPTION
This cropped up when building Cairo.jl on my machine.