### PR TITLE
Don't touch deps.jl at all if do_install is false

### DIFF
--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -795,33 +795,33 @@ macro install(_libmaps...)
                                 end
                             end
                         end
-                    end
 
-                    # Generate "deps.jl" file for runtime loading
-                    depsfile = open(joinpath(splitdir(Base.source_path())[1],"deps.jl"), "w")
-                    println(depsfile,
-                        """
-                        # This is an auto-generated file; do not edit
-                        """)
-                    println(depsfile, "# Pre-hooks")
-                    println(depsfile, join(pre_hooks, "\n"))
-                    println(depsfile,
-                        """
-                        # Macro to load a library
-                        macro checked_lib(libname, path)
-                            ((VERSION >= v"0.4.0-dev+3844" ? Base.Libdl.dlopen_e : Base.dlopen_e)(path) == C_NULL) && error("Unable to load \\n\\n\$libname (\$path)\\n\\nPlease re-run Pkg.build(package), and restart Julia.")
-                            quote const \$(esc(libname)) = \$path end
+                        # Generate "deps.jl" file for runtime loading
+                        depsfile = open(joinpath(splitdir(Base.source_path())[1],"deps.jl"), "w")
+                        println(depsfile,
+                            """
+                            # This is an auto-generated file; do not edit
+                            """)
+                        println(depsfile, "# Pre-hooks")
+                        println(depsfile, join(pre_hooks, "\n"))
+                        println(depsfile,
+                            """
+                            # Macro to load a library
+                            macro checked_lib(libname, path)
+                                ((VERSION >= v"0.4.0-dev+3844" ? Base.Libdl.dlopen_e : Base.dlopen_e)(path) == C_NULL) && error("Unable to load \\n\\n\$libname (\$path)\\n\\nPlease re-run Pkg.build(package), and restart Julia.")
+                                quote const \$(esc(libname)) = \$path end
+                            end
+                            """)
+                        println(depsfile, "# Load dependencies")
+                        for libkey in keys($libmaps)
+                            ((cached = get(load_cache,string(libkey),nothing)) === nothing) && continue
+                            println(depsfile, "@checked_lib ", $libmaps[libkey], " \"", escape_string(cached), "\"")
                         end
-                        """)
-                    println(depsfile, "# Load dependencies")
-                    for libkey in keys($libmaps)
-                        ((cached = get(load_cache,string(libkey),nothing)) === nothing) && continue
-                        println(depsfile, "@checked_lib ", $libmaps[libkey], " \"", escape_string(cached), "\"")
+                        println(depsfile)
+                        println(depsfile, "# Load-hooks")
+                        println(depsfile, join(load_hooks,"\n"))
+                        close(depsfile)
                     end
-                    println(depsfile)
-                    println(depsfile, "# Load-hooks")
-                    println(depsfile, join(load_hooks,"\n"))
-                    close(depsfile)
                 end))
         if !(typeof(libmaps) <: Associative)
             warn("Incorrect mapping in BinDeps.@install call. No dependencies will be cached.")


### PR DESCRIPTION
@Keno could you please take a look at this to see if it's in the spirit of the `do_install` flag?  Essentially, without this, when creating a `PackageContext` with `do_install` set to `false` (as [happens in `BinDeps.debug`](https://github.com/JuliaLang/BinDeps.jl/blob/1803cfc2c0b2a044b2753c8e634c2775185f0329/src/debug.jl#L51-L54)) `deps.jl` gets clobbered, wiping out the build configuration.  With this change, `deps.jl` doesn't get touched at all when `do_install` is set to `false`, which (as far as I can tell) is what is the intended behavior.  If there's some other circumstance I'm not thinking of, please let me know. [Here's one case](https://github.com/JuliaLang/BinDeps.jl/blob/1803cfc2c0b2a044b2753c8e634c2775185f0329/src/dependencies.jl#L889) where `do_install` is set to `false` (and I believe this case would also benefit from this change), but in [the last case](https://github.com/JuliaLang/BinDeps.jl/blob/1803cfc2c0b2a044b2753c8e634c2775185f0329/src/dependencies.jl#L959) where `do_install` is set to `false`, I'm less confident.  Thanks.