### PR TITLE
Fix dlopen c api change

### DIFF
--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -505,16 +505,28 @@ function _find_library(dep::LibraryDependency; provider = Any)
     return ret
 end
 
-function check_path!(ret,dep,opath)
-    flags = Libdl.RTLD_LAZY
-    handle = Libc.malloc(2*sizeof(Ptr{Void}))
-    err = ccall(:jl_uv_dlopen,Cint,(Ptr{UInt8},Ptr{Void},Cuint),opath,handle,flags)
-    if err == 0
-        check_system_handle!(ret,dep,handle)
-        Libdl.dlclose(handle)
-        # in Julia 0.4 handle is freed by dlclose.
-        if VERSION < v"0.4-"
-            c_free(handle)
+if VERSION < v"0.5.0-dev+1022"
+    function check_path!(ret,dep,opath)
+        flags = Libdl.RTLD_LAZY
+        handle = Libc.malloc(2*sizeof(Ptr{Void}))
+        err = ccall(:jl_uv_dlopen,Cint,(Ptr{UInt8},Ptr{Void},Cuint),opath,handle,flags)
+        if err == 0
+            check_system_handle!(ret,dep,handle)
+            Libdl.dlclose(handle)
+            # in Julia 0.4 handle is freed by dlclose.
+            if VERSION < v"0.4-"
+                c_free(handle)
+            end
+        end
+    end
+else
+    function check_path!(ret, dep, opath)
+        flags = Libdl.RTLD_LAZY
+        handle = ccall(:jl_dlopen, Ptr{Void}, (Ptr{UInt8}, Cuint), opath, flags)
+        try
+            check_system_handle!(ret, dep, handle)
+        finally
+            handle != C_NULL && Libdl.dlclose(handle)
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@
 
 using Base.Test
 using Compat
+using BinDeps
 
 Pkg.add("Cairo")  # Tests apt-get code paths
 using Cairo


### PR DESCRIPTION
Caused by JuliaLang/julia#13796

Also fix tests when the build is running in a separate process and BinDeps is not pulled in at runtime.

No additional tests added since the current test already trigger this path on my computer and it seems a little hard to trigger this path directly otherwise.

This shouldn't break 0.3 or 0.4 since everything new should be behind a version check.

Fix #184
