### PR TITLE
Prefix powershell with cmd to fix reduced shell command set in J 0.4.2.

### DIFF
--- a/src/BinDeps.jl
+++ b/src/BinDeps.jl
@@ -48,9 +48,9 @@ module BinDeps
         if downloadcmd === nothing
             for download_engine in @windows? (:powershell, :curl, :wget, :fetch) : (:curl, :wget, :fetch)
                 if download_engine == :powershell
-                    checkcmd = `$download_engine -help`
-                else
-                    checkcmd = `$download_engine --help`
+                    checkcmd = `cmd $download_engine new-variable foo`
+                 else
+                    checkcmd = `cmd $download_engine --help`
                 end
                 try
                     if success(checkcmd)
@@ -69,7 +69,7 @@ module BinDeps
         elseif downloadcmd == :fetch
             return `fetch -f $filename $url`
         elseif downloadcmd == :powershell
-            return `powershell -Command "(new-object net.webclient).DownloadFile(\"$url\", \"$filename\")"`
+            return `cmd powershell -Command "(new-object net.webclient).DownloadFile(\"$url\", \"$filename\")"`
         else
             error("No download agent available; install curl, wget, or fetch.")
         end


### PR DESCRIPTION
This secondarily "fixes" https://github.com/JuliaLang/BinDeps.jl/issues/192 by reducing unnecessary text output from Windows powershell. 

* The fixed issue may not appear on all Windows systems. This I assume depends on the context of ENV["PATH"], which is shared by many Windows 10 programs and shouldn't need to have special settings for Julia.

* Pkg.test("BinDeps") still fails due to an error in "HttpParser" ('deps.jl' is missing, but needed).

* The 'cmd' prefix has not been combined with the other download engines, as I'm unable to test it.

*  This ought to be tested on various Windows systems. 