### PR TITLE
Improve PowerShell calls in download_cmd

### DIFF
--- a/src/BinDeps.jl
+++ b/src/BinDeps.jl
@@ -49,7 +49,7 @@ module BinDeps
         if downloadcmd === nothing
             for download_engine in @windows? (:powershell, :curl, :wget, :fetch) : (:curl, :wget, :fetch)
                 if download_engine == :powershell
-                    checkcmd = `$download_engine -help`
+                    checkcmd = `$download_engine -NoProfile -Command ""`
                 else
                     checkcmd = `$download_engine --help`
                 end
@@ -70,7 +70,7 @@ module BinDeps
         elseif downloadcmd == :fetch
             return `fetch -f $filename $url`
         elseif downloadcmd == :powershell
-            return `powershell -Command "(new-object net.webclient).DownloadFile(\"$url\", \"$filename\")"`
+            return `powershell -NoProfile -Command "(new-object net.webclient).DownloadFile(\"$url\", \"$filename\")"`
         else
             error("No download agent available; install curl, wget, or fetch.")
         end


### PR DESCRIPTION
Two changes: 1) Change the call to PowerShell that is meant to detect whether PowerShell is on the system to not emit any output, 2) always specify the -NoProfile argument so that user PowerShell
startup scripts are not run.

Change 1) was suggested in #194.