### PR TITLE
Add tar.Z file support.

### DIFF
--- a/src/BinDeps.jl
+++ b/src/BinDeps.jl
@@ -77,7 +77,7 @@ module BinDeps
 
     @unix_only begin
         function unpack_cmd(file,directory,extension,secondary_extension)
-            if (extension == ".gz" && secondary_extension == ".tar") || extension == ".tgz"
+            if ((extension == ".gz" || extension == ".Z") && secondary_extension == ".tar") || extension == ".tgz"
                 return (`tar xzf $file --directory=$directory`)
             elseif (extension == ".bz2" && secondary_extension == ".tar") || extension == ".tbz"
                 return (`tar xjf $file --directory=$directory`)

--- a/src/BinDeps.jl
+++ b/src/BinDeps.jl
@@ -96,8 +96,8 @@ module BinDeps
 
     @windows_only begin
         function unpack_cmd(file,directory,extension,secondary_extension)
-            if((extension == ".gz" || extension == ".xz" || extension == ".bz2") && secondary_extension == ".tar") ||
-                   extension == ".tgz" || extension == ".tbz"
+            if((extension == ".Z" || extension == ".gz" || extension == ".xz" || extension == ".bz2") &&
+                   secondary_extension == ".tar") || extension == ".tgz" || extension == ".tbz"
                 return pipeline(`7z x $file -y -so`, `7z x -si -y -ttar -o$directory`)
             elseif extension == ".zip" || extension == ".7z"
                 return (`7z x $file -y -o$directory`)


### PR DESCRIPTION
`tar.Z` files can be unpacked with the same flags used for `tar.gz` files.