### PR TITLE
Turn on precompilation

### DIFF
--- a/src/BinDeps.jl
+++ b/src/BinDeps.jl
@@ -1,3 +1,4 @@
+isdefined(Base, :__precompile__) && __precompile__()
 module BinDeps
     importall Base
     using Compat


### PR DESCRIPTION
This should fix the intermittent package loading failure on many packages that depends on BinDeps (Notably ZMQ and IJulia).

If it is unsafe to turn precompilation on for this package, we should instead explicitly specify it to avoid the intermittent failure.
