### PR TITLE
unpack_cmd for .tar files under windows

### DIFF
--- a/src/BinDeps.jl
+++ b/src/BinDeps.jl
@@ -100,7 +100,7 @@ module BinDeps
             if((extension == ".Z" || extension == ".gz" || extension == ".xz" || extension == ".bz2") &&
                    secondary_extension == ".tar") || extension == ".tgz" || extension == ".tbz"
                 return pipeline(`7z x $file -y -so`, `7z x -si -y -ttar -o$directory`)
-            elseif extension == ".zip" || extension == ".7z"
+            elseif extension == ".zip" || extension == ".7z" || extension == ".tar"
                 return (`7z x $file -y -o$directory`)
             end
             error("I don't know how to unpack $file")


### PR DESCRIPTION
If a .tar file is not further compressed, it wasn't possible to unpack it under windows.