### PR TITLE
Check for `apt-cache` as well, as it's necessary for apt provider

### DIFF
--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -99,7 +99,7 @@ DEBIAN_VERSION_REGEX = r"^
           ([0-9][a-z0-9.+:~]*))                           # upstream version
 "ix
 
-const has_apt = try success(`apt-get -v`) catch e false end
+const has_apt = try success(`apt-get -v`) && success(`apt-cache -v`) catch e false end
 type AptGet <: PackageManager
     package::AbstractString
 end


### PR DESCRIPTION
This is useful in case you have a system like OpenSUSe where you can install `apt-get` for some reason, but `apt-cache` doesn't come with it; you still want to fallback to `Zypper`.