### PR TITLE
WIP: Depend on executables, implements #213

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,19 @@ There are a couple of other keyword arguments that are currently implemented:
 
 Other keyword arguments will most likely be added as necessary.
 
+## Executable Dependencies
+
+It is also possible to depend on the presence of executable files, either available on the
+system `PATH` (found using `which`, or `where` on Windows if `which` is not available) or 
+installed in `deps/usr/bin/`. E.g.:
+
+```julia
+python = executable_dependency("pip", aliases = ["pip2", "pip27"])
+```
+
+The above keyword arguments for `library_dependency` apply to this function with the 
+exception of `validate`, which accepts the path to the executable instead of the tuple.
+
 # The high level interface - Declaring build mechanisms
 
 Alright, now that we have declared all the dependencies that we
@@ -172,7 +185,7 @@ The basic signature of the provides function is
 ```
 
 where `data` is provider-specific (e.g. a string in all of the package manager 
-cases) and `dependency` is the return value from `library dependency. As you saw
+cases) and `dependency` is the return value from `library_dependency`. As you saw
 above multiple definitions may be combined into one function call as such:
 ```julia
 	provides(Provider,{data1=>dep1, data2=>dep2},options...)
@@ -190,13 +203,13 @@ There are also several builtin options. Some of them are:
 
  * `os = OS_NAME`
 
- 	This provider can only satisfy the library dependency on the specified `os`. 
+ 	This provider can only satisfy the dependency on the specified `os`. 
  	This argument takes has the same syntax as the `os` keyword argument to \
 	`library_dependency`.
 
- * `installed_libpath = "path"`
+ * `installed_path = "path"`
 
- 	If the provider installs a library dependency to someplace other than the
+ 	If the provider installs a dependency to someplace other than the
  	standard search paths, that location can be specified here.
 
  * `SHA = "sha"`
@@ -370,7 +383,7 @@ julia> using BinDeps
 julia> BinDeps.debug("Cairo")
 INFO: Reading build script...
 The package declares 1 dependencies.
- - Library Group "cairo" (satisfied by BinDeps.SystemPaths, BinDeps.SystemPaths)
+ - Dependency Group "cairo" (satisfied by BinDeps.SystemPaths, BinDeps.SystemPaths)
      - Library "png" (not applicable to this system)
      - Library "pixman" (not applicable to this system)
      - Library "ffi" (not applicable to this system)

--- a/src/debug.jl
+++ b/src/debug.jl
@@ -1,7 +1,8 @@
 import Base: show
 
-function _show_indented(io::IO, dep::LibraryDependency, indent, lib)
-    print_indented(io,"- Library \"$(dep.name)\"",indent+1)
+function _show_indented(io::IO, dep::Dependency, indent, lib)
+    deptype = isa(dep, LibraryDependency) ? "Library" : (isa(dep, ExecutableDependency) ? "Executable" : "")
+    print_indented(io,"- $deptype \"$(dep.name)\"",indent+1)
     if !applicable(dep)
         println(io," (not applicable to this system)")
     else
@@ -24,11 +25,11 @@ function _show_indented(io::IO, dep::LibraryDependency, indent, lib)
         end
     end
 end
-show_indented(io::IO, dep::LibraryDependency, indent) = _show_indented(io,dep,indent, applicable(dep) ? _find_library(dep) : nothing)
-show(io::IO, dep::LibraryDependency) = show_indented(io, dep, 0)
+show_indented(io::IO, dep::Dependency, indent) = _show_indented(io,dep,indent, applicable(dep) ? _find_dependency(dep) : nothing)
+show(io::IO, dep::Dependency) = show_indented(io, dep, 0)
 
-function show(io::IO, deps::LibraryGroup)
-    print(io," - Library Group \"$(deps.name)\"")
+function show(io::IO, deps::DependencyGroup)
+    print(io," - Dependency Group \"$(deps.name)\"")
     all = allf(deps)
     providers = satisfied_providers(deps,all)
     if providers != nothing && !(isempty(providers))

--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -333,7 +333,8 @@ type CustomPathBinaries <: Binaries
     path::AbstractString
 end
 
-libdir(p::CustomPathBinaries,dep) = p.path
+libdir(p::CustomPathBinaries, dep) = p.path
+bindir(p::CustomPathBinaries, dep) = p.path
 
 abstract BuildProcess <: DependencyProvider
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,3 +11,5 @@ using HttpParser
 
 # PR 171
 @test BinDeps.lower(nothing, nothing) === nothing
+
+include("testscripts/executable/build.jl")

--- a/test/testscripts/executable/build.jl
+++ b/test/testscripts/executable/build.jl
@@ -1,0 +1,43 @@
+using BinDeps
+
+@windows_only begin
+    const sh_file = chomp(readlines(`where cmd`)[1])
+    const sh_dest_file = "bindeps_sh_test.exe"
+    copyfile(src, dest) = cp(src, dest; remove_destination=true)
+
+    function validate(path)
+        success(`$path /Q`)
+    end
+end
+@unix_only begin
+    const sh_file = chomp(readlines(`which sh`)[1])
+    const sh_dest_file = "bindeps_sh_test"
+    copyfile(src, dest) = success(`cp $src $dest`)
+
+    function validate(path)
+        success(`sh --help`)
+    end
+end
+
+
+@BinDeps.setup
+
+sh_test = executable_dependency("bindeps_sh_test", validate=validate)
+
+sh_test_dir = BinDeps.bindir(sh_test)
+sh_dest = joinpath(sh_test_dir, sh_dest_file)
+mkpath(sh_test_dir)
+
+provides(SimpleBuild, (@build_steps begin
+    ()->copyfile(sh_file, sh_dest)
+end), sh_test)
+
+@BinDeps.install Dict([(:bindeps_sh_test, :sh_test)])
+
+module Installed
+include("./deps.jl")
+end
+
+@test validate(Installed.sh_test)
+
+rm(Installed.sh_test)

--- a/test/testscripts/executable/build.jl
+++ b/test/testscripts/executable/build.jl
@@ -1,36 +1,17 @@
 using BinDeps
 
-@windows_only begin
-    const sh_file = chomp(readlines(`where cmd`)[1])
-    const sh_dest_file = "bindeps_sh_test.exe"
-    copyfile(src, dest) = cp(src, dest; remove_destination=true)
-
-    function validate(path)
-        success(`$path /Q`)
-    end
-end
-@unix_only begin
-    const sh_file = chomp(readlines(`which sh`)[1])
-    const sh_dest_file = "bindeps_sh_test"
-    copyfile(src, dest) = success(`cp $src $dest`)
-
-    function validate(path)
-        success(`sh --help`)
+function validate(path)
+    if basename(path) == "sh"
+        return success(`$path --help`)
+    else
+        return success(`$path /Q`)
     end
 end
 
 
 @BinDeps.setup
 
-sh_test = executable_dependency("bindeps_sh_test", validate=validate)
-
-sh_test_dir = BinDeps.bindir(sh_test)
-sh_dest = joinpath(sh_test_dir, sh_dest_file)
-mkpath(sh_test_dir)
-
-provides(SimpleBuild, (@build_steps begin
-    ()->copyfile(sh_file, sh_dest)
-end), sh_test)
+sh_test = executable_dependency("bindeps_sh_test", aliases=["sh", "cmd.exe"], validate=validate)
 
 @BinDeps.install Dict([(:bindeps_sh_test, :sh_test)])
 
@@ -39,5 +20,3 @@ include("./deps.jl")
 end
 
 @test validate(Installed.sh_test)
-
-rm(Installed.sh_test)


### PR DESCRIPTION
Users can now declare `executable_dependency` and have it work just like `library_dependency`. 

Unfortunately as far as I can tell there is no easy way in Julia to check if a file is executable on Windows. However, I ensured that files with `PATHEXT` executable extensions are preferred. 

Currently `install` will write a variable `_exec` to deps.jl which contains a dictionary of dependency names and paths to executables. Please let me know if there is a better way. I mostly left `load_dependencies` alone, so it still gives tuples where the second element is the path. It's not clear whether including `deps.jl` or calling `load_dependencies` is preferred, and the results for doing either are undocumented. If someone knows the recommended way to approach this, I can document it. 

It's unclear to me how to test this new feature. Would the best approach be to just create and run a build script with an arbitrary executable dependency? The current approach seems to use build scripts from other packages, but since it's a new feature, no packages are using it. I have been testing with my build script for the unreleased EphemeralPG.

Work left:
- [x] Document `executable_dependency` ~~and the recommended way of loading dependencies~~
- [x] Adapt the Autotools build process for executable dependencies
- [x] Test
- [x] ~~Fix or~~ get around https://github.com/JuliaLang/Compat.jl/issues/187 (currently causing 0.4 failure)

This is here in WIP state so I can get comments sooner rather than later.
