### PR TITLE
Fix depwarn on 0.5 about symbol and ASCIIString

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.3
 URIParser
 SHA
-Compat 0.7.1
+Compat 0.7.14+

--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -106,7 +106,7 @@ end
 can_use(::Type{AptGet}) = has_apt && OS_NAME == :Linux
 package_available(p::AptGet) = can_use(AptGet) && !isempty(available_versions(p))
 function available_versions(p::AptGet)
-    vers = ASCIIString[]
+    vers = _ASCIIString[]
     lookfor_version = false
     for l in eachline(`apt-cache showpkg $(p.package)`)
         if startswith(l,"Version:")
@@ -437,13 +437,13 @@ function generate_steps(dep::LibraryDependency, h::Autotools,  provider_opts)
     merge!(opts,h.opts)
     if haskey(opts,:installed_libname)
         !haskey(opts,:installed_libpath) || error("Can't specify both installed_libpath and installed_libname")
-        opts[:installed_libpath] = ByteString[joinpath(libdir(dep),opts[:installed_libname])]
+        opts[:installed_libpath] = _ByteString[joinpath(libdir(dep),opts[:installed_libname])]
         delete!(opts, :installed_libname)
     elseif !haskey(opts,:installed_libpath)
-        opts[:installed_libpath] = ByteString[joinpath(libdir(dep),x)*"."*dlext for x in stringarray(get(dep.properties,:aliases,ByteString[]))]
+        opts[:installed_libpath] = _ByteString[joinpath(libdir(dep),x)*"."*dlext for x in stringarray(get(dep.properties,:aliases,_ByteString[]))]
     end
     if !haskey(opts,:libtarget) && haskey(dep.properties,:aliases)
-        opts[:libtarget] = ByteString[x*"."*dlext for x in stringarray(dep.properties[:aliases])]
+        opts[:libtarget] = _ByteString[x*"."*dlext for x in stringarray(dep.properties[:aliases])]
     end
     if !haskey(opts,:include_dirs)
         opts[:include_dirs] = AbstractString[]
@@ -465,7 +465,7 @@ function generate_steps(dep::LibraryDependency, h::Autotools,  provider_opts)
     unshift!(opts[:lib_dirs],libdir(dep))
     unshift!(opts[:rpath_dirs],libdir(dep))
     unshift!(opts[:pkg_config_dirs],joinpath(libdir(dep),"pkgconfig"))
-    env = Dict{ByteString,ByteString}()
+    env = Dict{_ByteString,_ByteString}()
     env["PKG_CONFIG_PATH"] = join(opts[:pkg_config_dirs],":")
     delete!(opts,:pkg_config_dirs)
     @unix_only env["PATH"] = bindir(dep)*":"*ENV["PATH"]
@@ -488,7 +488,7 @@ const EXTENSIONS = ["", "." * Libdl.dlext]
 function _find_library(dep::LibraryDependency; provider = Any)
     ret = Any[]
     # Same as find_library, but with extra check defined by dep
-    libnames = [dep.name;get(dep.properties,:aliases,ASCIIString[])]
+    libnames = [dep.name;get(dep.properties,:aliases,_ASCIIString[])]
     # Make sure we keep the defaults first, but also look in the other directories
     providers = unique([reduce(vcat,[getallproviders(dep,p) for p in defaults]);dep.providers])
     for (p,opts) in providers
@@ -989,7 +989,7 @@ macro load_dependencies(args...)
                 error("Can't deal with argument type $(typeof(arg1)). See usage instructions!")
             end
         end
-        s = symbol(sym)
+        s = @compat Symbol(sym)
         errorcase = Expr(:block)
         push!(errorcase.args,:(error("Could not load library "*$(dep.name)*". Try running Pkg.build() to install missing dependencies!")))
         push!(ret.args,quote


### PR DESCRIPTION
Requires a new tag of Compat.jl for `symbol`. I'm not sure if there's a better way to handle `ASCIIString` since there's apparently other packages that depend on this type (it's used in `Conda` for example).