### PR TITLE
Move installation of Cairo and HttpParser to test/REQUIRE

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,2 @@
+Cairo
+HttpParser

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,11 +4,9 @@ using Base.Test
 using Compat
 using BinDeps
 
-Pkg.add("Cairo")  # Tests apt-get code paths
-Pkg.build("Cairo")
+Pkg.build("Cairo")  # Tests apt-get code paths
 using Cairo
-Pkg.add("HttpParser")  # Tests build-from-source code paths
-Pkg.build("HttpParser")
+Pkg.build("HttpParser")  # Tests build-from-source code paths
 using HttpParser
 
 # PR 171


### PR DESCRIPTION
this removes them after testing is done if the user didn't already have them installed