### PR TITLE
Add @compat for Symbol construction on 0.3

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,4 +33,4 @@ build_script:
       Pkg.clone(pwd(), \"BinDeps\"); Pkg.build(\"BinDeps\")"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"BinDeps\")"
+  - C:\projects\julia\bin\julia -F -e "Pkg.test(\"BinDeps\")"

--- a/src/BinDeps.jl
+++ b/src/BinDeps.jl
@@ -207,7 +207,7 @@ module BinDeps
             end
             while true
                 print("Plese select desired method: ")
-                method = Symbol(chomp(readline(STDIN)))
+                method = @compat Symbol(chomp(readline(STDIN)))
                 for x in c.choices
                     if(method == x.name)
                         return run(x.step)

--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -993,7 +993,7 @@ macro load_dependencies(args...)
                 error("Can't deal with argument type $(typeof(arg1)). See usage instructions!")
             end
         end
-        s = Symbol(sym)
+        s = @compat Symbol(sym)
         errorcase = Expr(:block)
         push!(errorcase.args,:(error("Could not load library "*$(dep.name)*". Try running Pkg.build() to install missing dependencies!")))
         push!(ret.args,quote

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,3 @@
 Cairo
 HttpParser
-GSL
+@unix GSL # TODO: remove @unix when BinDeps no longer supports julia 0.3

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,3 @@
 Cairo
 HttpParser
+GSL

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,8 +8,10 @@ Pkg.build("Cairo")  # Tests apt-get code paths
 using Cairo
 Pkg.build("HttpParser")  # Tests build-from-source code paths
 using HttpParser
-Pkg.build("GSL")  # Tests old-style @load_dependencies, at least on 0.3
-using GSL
+if is_unix()
+    Pkg.build("GSL")  # Tests old-style @load_dependencies, at least on 0.3
+    using GSL
+end
 
 # PR 171
 @test BinDeps.lower(nothing, nothing) === nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,8 @@ Pkg.build("Cairo")  # Tests apt-get code paths
 using Cairo
 Pkg.build("HttpParser")  # Tests build-from-source code paths
 using HttpParser
+Pkg.build("GSL")  # Tests old-style @load_dependencies, at least on 0.3
+using GSL
 
 # PR 171
 @test BinDeps.lower(nothing, nothing) === nothing


### PR DESCRIPTION
broke old versions of GSL, see e.g. https://travis-ci.org/tkelman/BinDeps.jl/jobs/146277261

appveyor nightly issue should be fixed by https://github.com/JuliaLang/METADATA.jl/pull/5659