### PR TITLE
Fix OS_NAME dep warn

### DIFF
--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -619,7 +619,7 @@ end
 
 function applicable(dep::LibraryDependency)
     if haskey(dep.properties,:os)
-        if (dep.properties[:os] != OS_NAME && dep.properties[:os] != :Unix) || (dep.properties[:os] == :Unix && !is_unix())
+        if (dep.properties[:os] != Compat.KERNEL && dep.properties[:os] != :Unix) || (dep.properties[:os] == :Unix && !is_unix())
             return false
         end
     elseif haskey(dep.properties,:runtime) && dep.properties[:runtime] == false
@@ -631,7 +631,7 @@ end
 applicable(deps::LibraryGroup) = any([applicable(dep) for dep in deps.deps])
 
 function can_provide(p,opts,dep)
-    if p === nothing || (haskey(opts,:os) && opts[:os] != OS_NAME && (opts[:os] != :Unix || !is_unix()))
+    if p === nothing || (haskey(opts,:os) && opts[:os] != Compat.KERNEL && (opts[:os] != :Unix || !is_unix()))
         return false
     end
     if !haskey(opts,:validate)
@@ -644,7 +644,7 @@ function can_provide(p,opts,dep)
 end
 
 function can_provide(p::PackageManager,opts,dep)
-    if p === nothing || (haskey(opts,:os) && opts[:os] != OS_NAME && (opts[:os] != :Unix || !is_unix()))
+    if p === nothing || (haskey(opts,:os) && opts[:os] != Compat.KERNEL && (opts[:os] != :Unix || !is_unix()))
         return false
     end
     if !package_available(p)

--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -1,6 +1,6 @@
 # This is the high level interface for building dependencies using the declarative BinDeps Interface
 import Base: show
-const OSNAME = @static is_windows() ? :Windows : Compat.KERNEL
+const OSNAME = is_windows() ? :Windows : Compat.KERNEL
 
 # A dependency provider, if successfully executed will satisfy the dependency
 abstract DependencyProvider
@@ -645,8 +645,7 @@ function can_provide(p,opts,dep)
 end
 
 function can_provide(p::PackageManager,opts,dep)
-    if p === nothing || (haskey(opts,:os) && opts[:os] != OSNAME && 
-        (opts[:os] != :Unix || !is_unix()))
+    if p === nothing || (haskey(opts,:os) && opts[:os] != OSNAME && (opts[:os] != :Unix || !is_unix()))
         return false
     end
     if !package_available(p)

--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -1,5 +1,6 @@
 # This is the high level interface for building dependencies using the declarative BinDeps Interface
 import Base: show
+const OSNAME = @static is_windows() ? :Windows : Compat.KERNEL
 
 # A dependency provider, if successfully executed will satisfy the dependency
 abstract DependencyProvider
@@ -619,8 +620,7 @@ end
 
 function applicable(dep::LibraryDependency)
     if haskey(dep.properties,:os)
-        if (dep.properties[:os] != (@compat @static is_unix() ? Compat.KERNEL : :NT) 
-            && dep.properties[:os] != :Unix) || (dep.properties[:os] == :Unix && !is_unix())
+        if (dep.properties[:os] != OSNAME && dep.properties[:os] != :Unix) || (dep.properties[:os] == :Unix && !is_unix())
             return false
         end
     elseif haskey(dep.properties,:runtime) && dep.properties[:runtime] == false
@@ -632,8 +632,7 @@ end
 applicable(deps::LibraryGroup) = any([applicable(dep) for dep in deps.deps])
 
 function can_provide(p,opts,dep)
-    if p === nothing || (haskey(opts,:os) && 
-        opts[:os] != (@compat @static is_unix() ? Compat.KERNEL : :NT) && (opts[:os] != :Unix || !is_unix()))
+    if p === nothing || (haskey(opts,:os) && opts[:os] != OSNAME && (opts[:os] != :Unix || !is_unix()))
         return false
     end
     if !haskey(opts,:validate)
@@ -646,7 +645,7 @@ function can_provide(p,opts,dep)
 end
 
 function can_provide(p::PackageManager,opts,dep)
-    if p === nothing || (haskey(opts,:os) && opts[:os] != (@compat @static is_unix() ? Compat.KERNEL : :NT) && 
+    if p === nothing || (haskey(opts,:os) && opts[:os] != OSNAME && 
         (opts[:os] != :Unix || !is_unix()))
         return false
     end

--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -619,7 +619,8 @@ end
 
 function applicable(dep::LibraryDependency)
     if haskey(dep.properties,:os)
-        if (dep.properties[:os] != Compat.KERNEL && dep.properties[:os] != :Unix) || (dep.properties[:os] == :Unix && !is_unix())
+        if (dep.properties[:os] != (@compat @static is_unix() ? Compat.KERNEL : :NT) 
+            && dep.properties[:os] != :Unix) || (dep.properties[:os] == :Unix && !is_unix())
             return false
         end
     elseif haskey(dep.properties,:runtime) && dep.properties[:runtime] == false
@@ -631,7 +632,8 @@ end
 applicable(deps::LibraryGroup) = any([applicable(dep) for dep in deps.deps])
 
 function can_provide(p,opts,dep)
-    if p === nothing || (haskey(opts,:os) && opts[:os] != Compat.KERNEL && (opts[:os] != :Unix || !is_unix()))
+    if p === nothing || (haskey(opts,:os) && 
+        opts[:os] != (@compat @static is_unix() ? Compat.KERNEL : :NT) && (opts[:os] != :Unix || !is_unix()))
         return false
     end
     if !haskey(opts,:validate)
@@ -644,7 +646,8 @@ function can_provide(p,opts,dep)
 end
 
 function can_provide(p::PackageManager,opts,dep)
-    if p === nothing || (haskey(opts,:os) && opts[:os] != Compat.KERNEL && (opts[:os] != :Unix || !is_unix()))
+    if p === nothing || (haskey(opts,:os) && opts[:os] != (@compat @static is_unix() ? Compat.KERNEL : :NT) && 
+        (opts[:os] != :Unix || !is_unix()))
         return false
     end
     if !package_available(p)


### PR DESCRIPTION
`OS_NAME` to `Compat.KERNEL`

Fixes #223 