### PR TITLE
Drop 0.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.3
   - 0.4
   - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.3
+julia 0.4
 URIParser
 SHA
 Compat 0.8.4

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.3/julia-0.3-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.3/julia-0.3-latest-win64.exe"
   - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
   - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,3 @@
 Cairo
 HttpParser
-@unix GSL # TODO: remove @unix when BinDeps no longer supports julia 0.3
+GSL

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,10 +8,8 @@ Pkg.build("Cairo")  # Tests apt-get code paths
 using Cairo
 Pkg.build("HttpParser")  # Tests build-from-source code paths
 using HttpParser
-if is_unix()
-    Pkg.build("GSL")  # Tests old-style @load_dependencies, at least on 0.3
-    using GSL
-end
+Pkg.build("GSL")
+using GSL
 
 # PR 171
 @test BinDeps.lower(nothing, nothing) === nothing


### PR DESCRIPTION
latest updates have started triggering mysterious
'new not defined' errors on PackageEvaluator for a
few packages, and rather than debug those I think
we may as well drop 0.3 support and make the latest
tags 0.4-only.

xref https://github.com/JuliaLang/METADATA.jl/pull/5674