### PR TITLE
Fix unzip usage on bsd

### DIFF
--- a/src/BinDeps.jl
+++ b/src/BinDeps.jl
@@ -91,7 +91,11 @@ if is_unix()
         elseif extension == ".tar"
             return (`tar xf $file --directory=$directory`)
         elseif extension == ".zip"
-            return (`unzip -x $file -d $directory`)
+            @static if is_bsd() && !is_apple()
+                return (`unzip -x $file -d $directory $file`)
+            else
+                return (`unzip -x $file -d $directory`)
+            end
         elseif extension == ".gz"
             return pipeline(`mkdir $directory`, `cp $file $directory`, `gzip -d $directory/$file`)
         end


### PR DESCRIPTION
On FreeBSD and NetBSD:
```
$ unzip 
Usage: unzip [-aCcfjLlnopqtuvyZ1] [-d dir] [-x pattern] zipfile
```