### PR TITLE
Use `eval()` within `debug()` to force a new world age

### DIFF
--- a/src/debug.jl
+++ b/src/debug.jl
@@ -58,8 +58,14 @@ end
 function debug(io,pkg::AbstractString)
     context = debug_context(pkg)
     println(io,"The package declares $(length(context.deps)) dependencies.")
-    for dep in context.deps
-        show(io,dep)
+    
+    # We need to `eval()` the rest of this function because `debug_context()` will
+    # `eval()` in things like `Homebrew.jl`, which contain new methods for things
+    # like `can_provide()`, and we cannot deal with those new methods in our
+    # current world age; we need to `eval()` to force ourselves up into a newer
+    # world age.
+    @eval for dep in $(context.deps)
+        show($io,dep)
     end
 end
 debug(pkg::AbstractString) = debug(STDOUT,pkg)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,3 +11,6 @@ using GSL
 
 # PR 171
 @test BinDeps.lower(nothing, nothing) === nothing
+
+# PR 271
+BinDeps.debug("Cairo")


### PR DESCRIPTION
This is to fix problems such as https://github.com/JuliaPackaging/Homebrew.jl/issues/187, where `eval()`'ing in the `build.jl` file of a dependency causes the evaluation of `using Homebrew` which adds methods such as `can_provide()` into the method table, and then causes problems when `BinDeps` itself tries to call `can_provide()` later on within the same function.  Because we have not had a chance to return to global scope, we're still running within the world age defined when the `debug()` function was originally called, and thus the methods imported by `Homebrew` are from a world age that's newer than the one we're currently running within.

This fix forces the rest of the `debug()` method to run in a new world age by using `eval()`.