### PR TITLE
update reccomended way to load dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ provides(Sources,URI("http://libvirt.org/sources/libvirt-1.1.1-rc2.tar.gz"),libv
 
 To load dependencies without a runtime dependence on BinDeps, place code like the following near the start of the module's primary file. Don't forget to change the error message to reflect the name of your package.
 ```julia
-const depsfile = joinpath(dirname(@__DIR__), "deps", "deps.jl")
+const depsfile = joinpath(dirname(@__FILE__), "deps", "deps.jl")
 if isfile(depsfile)
     include(depsfile)
 else

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ To load dependencies without a runtime dependence on BinDeps, place code like th
 near the start of the Package's primary file. Don't forget to change the error message to 
 reflect the name of the package.
 ```julia
-const depsfile = joinpath(dirname(@__FILE__),"..", "deps", "deps.jl")
+const depsfile = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
 if isfile(depsfile)
     include(depsfile)
 else
@@ -268,11 +268,11 @@ end
 
 This will make all your libraries available as variables named by the names you gave the 
 dependency. E.g. if you declared a dependency as
-  ```julia
- 	library_dependency("libfoo")
- ```
- The `libfoo` variable will now contain a reference to that library that may be passed
- to `ccall` or similar functions. 
+```julia
+library_dependency("libfoo")
+```
+The `libfoo` variable will now contain a reference to that library that may be passed
+to `ccall` or similar functions. 
 
 # The low level interface
 	

--- a/README.md
+++ b/README.md
@@ -254,7 +254,9 @@ provides(Sources,URI("http://libvirt.org/sources/libvirt-1.1.1-rc2.tar.gz"),libv
 
 # The high level interface - Loading dependencies
 
-To load dependencies without a runtime dependence on BinDeps, place code like the following near the start of the module's primary file. Don't forget to change the error message to reflect the name of your package.
+To load dependencies without a runtime dependence on BinDeps, place code like the following
+near the start of the Package's primary file. Don't forget to change the error message to 
+reflect the name of the package.
 ```julia
 const depsfile = joinpath(dirname(@__FILE__), "deps", "deps.jl")
 if isfile(depsfile)
@@ -263,6 +265,14 @@ else
     error("HDF5 not properly installed. Please run Pkg.build(\"HDF5\")")
 end
 ```
+
+This will make all your libraries available as variables named by the names you gave the 
+dependency. E.g. if you declared a dependency as
+  ```julia
+ 	library_dependency("libfoo")
+ ```
+ The `libfoo` variable will now contain a reference to that library that may be passed
+ to `ccall` or similar functions. 
 
 # The low level interface
 	

--- a/README.md
+++ b/README.md
@@ -254,41 +254,15 @@ provides(Sources,URI("http://libvirt.org/sources/libvirt-1.1.1-rc2.tar.gz"),libv
 
 # The high level interface - Loading dependencies
 
-BinDeps provides the `@BinDeps.load_dependencies` macro that you may call early in 
-initialization process of your package to load all declared libraries in your build.jl
-file. 
-
-The basic usage is very simple:
-
-```jl
-using BinDeps
-@BinDeps.load_dependencies
-```
-
-This will make all your libraries available as variables named by the names you gave 
-the dependency. E.g. if you declared a dependency as
-
+To load dependencies without a runtime dependence on BinDeps, place code like the following near the start of the module's primary file. Don't forget to change the error message to reflect the name of your package.
 ```julia
-	library_dependency("libfoo")
+const depsfile = joinpath(dirname(@__DIR__), "deps", "deps.jl")
+if isfile(depsfile)
+    include(depsfile)
+else
+    error("HDF5 not properly installed. Please run Pkg.build(\"HDF5\")")
+end
 ```
-
-The `libfoo` variable will now contain a reference to that library that may be passed
-to `ccall` or similar functions. 
-
-If you only want to load a subset of the declared dependencies you may pass the macro
-a list of libraries to load, e.g. 
-```julia
-@BinDeps.load_dependencies [:libfoo, :libbar]
-```
-
-if you do not want to change the names of the variables that these libraries get 
-stored in, you may use
-
-```julia
-@BinDeps.load_dependencies [:libfoo=>:_foo, :libbar=>:_bar]
-```
-
-which will assign the result to the `_foo` and `_bar` variables instead. 
 
 # The low level interface
 	

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ To load dependencies without a runtime dependence on BinDeps, place code like th
 near the start of the Package's primary file. Don't forget to change the error message to 
 reflect the name of the package.
 ```julia
-const depsfile = joinpath(dirname(@__FILE__), "deps", "deps.jl")
+const depsfile = joinpath(dirname(@__FILE__),"..", "deps", "deps.jl")
 if isfile(depsfile)
     include(depsfile)
 else

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ const depsfile = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
 if isfile(depsfile)
     include(depsfile)
 else
-    error("HDF5 not properly installed. Please run Pkg.build(\"HDF5\")")
+    error("HDF5 not properly installed. Please run Pkg.build(\"HDF5\") then restart Julia.")
 end
 ```
 


### PR DESCRIPTION
Reflecting #196, stop recommending `@load_dependencies` since it doesn't work. Instead provide a few lines of code taken from HDF5.jl that will load deps.jl. [ci skip]