### PR TITLE
Drop support for 0.5, fix all 0.7 depwarns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
   - 0.6
   - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.6
 URIParser
 SHA
-Compat 0.17.0
+Compat 0.27.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"


### PR DESCRIPTION
Going forward if there's anything that needs fixing that applies to old versions we can always backport the change and make another 0.5-compatible release. But it makes sense to me to focus on what's easier to maintain going forward. Plus there are a lot of deprecation warnings on nightly which contribute to the thousands of lines of depwarns in Nanosoldier's logs.