### PR TITLE
Compat.ASCIIString -> String

### DIFF
--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -106,7 +106,7 @@ end
 can_use(::Type{AptGet}) = has_apt && is_linux()
 package_available(p::AptGet) = can_use(AptGet) && !isempty(available_versions(p))
 function available_versions(p::AptGet)
-    vers = Compat.ASCIIString[]
+    vers = String[]
     lookfor_version = false
     for l in eachline(`apt-cache showpkg $(p.package)`)
         if startswith(l,"Version:")


### PR DESCRIPTION
Remove deprecation warning on Julia 0.6