### PR TITLE
Revert "Add Binaries installation method on Linux"

### DIFF
--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -725,7 +725,7 @@ end
 if Compat.Sys.isapple()
     defaults = [Binaries,PackageManager,SystemPaths,BuildProcess]
 elseif Compat.Sys.islinux() || (Compat.Sys.isbsd() && !Compat.Sys.isapple())
-    defaults = [PackageManager,SystemPaths,Binaries,BuildProcess]
+    defaults = [PackageManager,SystemPaths,BuildProcess]
 elseif Compat.Sys.iswindows()
     defaults = [Binaries,PackageManager,SystemPaths]
 else


### PR DESCRIPTION
Reverts JuliaLang/BinDeps.jl#326. Non-glibc linux distros exist and Julia runs on them, glibc-built binaries should never be used there.