### PR TITLE
Add glibc_version for checking the glibc version

### DIFF
--- a/src/BinDeps.jl
+++ b/src/BinDeps.jl
@@ -8,7 +8,7 @@ export @make_run, @build_steps, find_library, download_cmd, unpack_cmd,
     Choice, Choices, CCompile, FileDownloader, FileRule,
     ChangeDirectory, FileDownloader, FileUnpacker, prepare_src,
     autotools_install, CreateDirectory, MakeTargets, SystemLibInstall,
-    MAKE_CMD
+    MAKE_CMD, glibc_version
 
 function find_library(pkg,libname,files)
     Base.warn_once("BinDeps.find_library is deprecated; use Base.find_library instead.")
@@ -559,6 +559,21 @@ function eval_anon_module(context, file)
         eval(m, body)
     end
     return
+end
+
+"""
+    glibc_version()
+
+For Linux-based systems, return the version of glibc in use. For non-glibc Linux and
+other platforms, returns `nothing`.
+"""
+function glibc_version()
+    Compat.Sys.islinux() || return
+    libc = ccall(:jl_dlopen, Ptr{Void}, (Ptr{Void}, UInt32), C_NULL, 0)
+    ptr = Libdl.dlsym_e(libc, :gnu_get_libc_version)
+    ptr == C_NULL && return # non-glibc
+    v = unsafe_string(ccall(ptr, Ptr{UInt8}, ()))
+    ismatch(Base.VERSION_REGEX, v) ? VersionNumber(v) : nothing
 end
 
 include("dependencies.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,3 +14,18 @@ using GSL
 
 # PR 271
 BinDeps.debug("Cairo")
+
+let gv = glibc_version()
+    if Compat.Sys.islinux()
+        lddv = lowercase(readchomp(`ldd --version`))
+        if contains(lddv, "gnu") || contains(lddv, "glibc")
+            @test isa(gv, VersionNumber)
+            @test gv >= v"1.0.0"
+        else
+            # Assume non-glibc
+            @test gv === nothing
+        end
+    else
+        @test gv === nothing
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,10 @@
-using Base.Test
 using Compat
 using BinDeps
+if VERSION < v"0.7.0-DEV.2004"
+    using Base.Test
+else
+    using Test
+end
 
 Pkg.build("Cairo")  # Tests apt-get code paths
 using Cairo


### PR DESCRIPTION
This PR adds a function I've called `glibc_version` that returns the version of glibc in use by Julia (as accessible from `dlopen`) on glibc-based Linux systems. For all other systems, including musl Linux, this returns `nothing`.

When binaries are available on Linux, this should make it easy to check whether the current system is compatible with the binaries (at least in the sense of a compatible libc).