### PR TITLE
use jl_read_sonames and jl_lookup_soname on older julia versions

### DIFF
--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -426,7 +426,7 @@ if VERSION >= v"0.7.0-DEV.1287" # only use this where julia issue #22832 is fixe
     end
 else
     function lookup_soname(lib)
-        if is_linux() || (is_bsd() && !is_apple())
+        if Compat.Sys.islinux() || (Compat.Sys.isbsd() && !Compat.Sys.isapple())
             soname = ccall(:jl_lookup_soname, Ptr{UInt8}, (Ptr{UInt8}, Csize_t), lib, sizeof(lib))
             soname != C_NULL && return unsafe_string(soname)
         end


### PR DESCRIPTION
use the code path from before #277 on versions of julia where the new code freezes
ref https://github.com/JuliaStats/Rmath.jl/issues/38

This is needed before master is safe to make another tag from, without breaking on release versions of Julia.