### PR TITLE
RFC: Customizable priorities for source building

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,3 +380,43 @@ The package declares 1 dependencies.
           - BinDeps.Yum package gettext-libs (can't provide)
           - Autotools Build
 ```
+
+# Special settings
+
+At startup, BinDeps checks whether `sudo` is installed on the system, since it's used
+for installing from package managers.
+To disable the check *and* the use of `sudo`, set an environment variable
+`JULIA_BINDEPS_USE_SUDO` equal to `false`.
+Setting this variable to `true` will also disable the check but will assume that `sudo`
+is available.
+
+Some users may prefer to build all dependencies from source rather than using any
+available binaries or installing from package managers.
+To enable this, set an environment variable `JULIA_BINDEPS_BUILD_SOURCE` equal to one
+of the following values:
+
+* `always`: Entirely **disable** installation from any providers other than `BuildProcess`.
+  Note that depending how a particular package is set up, you may not be able to install
+  it at all if it doesn't provide a method for building from source. Use this option with
+  caution.
+
+* `prefer`: Build from source if a `BuildProcess` is available, otherwise use other
+  available providers.
+
+* `never`: Entirely **disable** building from source. This means that packages that only
+  specify `BuildProcess` providers will not be installable. This option is not generally
+  recommended unless no build tools are available or installable on your system. Again,
+  use with caution.
+
+* `default`: Allow building from source with the default priority level. This is the same
+  as not specifying this variable at all.
+
+Note that this applies to `BuildProcess` only; `SimpleBuild` is always enabled.
+
+These settings are checked every time BinDeps starts up, so to have them persist across
+sessions, you can add entries like this to your .juliarc.jl file:
+
+```julia
+ENV["JULIA_BINDEPS_USE_SUDO"] = "false"
+ENV["JULIA_BINDEPS_BUILD_SOURCE"] = "prefer"
+```

--- a/src/BinDeps.jl
+++ b/src/BinDeps.jl
@@ -586,8 +586,27 @@ include("show.jl")
 @Base.deprecate_binding shlib_ext Libdl.dlext
 
 const has_sudo = Ref{Bool}(false)
+const build_source = Ref{String}("default")
+
 function __init__()
-    has_sudo[] = try success(`sudo -V`) catch err false end
+    # install from package managers with sudo
+    has_sudo[] = if haskey(ENV, "JULIA_BINDEPS_USE_SUDO")
+        ENV["JULIA_BINDEPS_USE_SUDO"] == "true"
+    else
+        try
+            success(`sudo -V`)
+        catch err
+            false
+        end
+    end
+
+    # preference for building from source
+    build_source[] = let opt = get(ENV, "JULIA_BINDEPS_BUILD_SOURCE", "default")
+        if !in(opt, ["default", "always", "never", "prefer"])
+            error("Unrecognized value '$opt' for environment variable JULIA_BINDEPS_BUILD_SOURCE")
+        end
+        opt
+    end
 end
 
 end

--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -722,14 +722,29 @@ function check_system_handle!(ret,dep,handle)
 end
 
 # Default installation method
-if Compat.Sys.isapple()
-    defaults = [Binaries,PackageManager,SystemPaths,BuildProcess]
-elseif Compat.Sys.islinux() || (Compat.Sys.isbsd() && !Compat.Sys.isapple())
-    defaults = [PackageManager,SystemPaths,Binaries,BuildProcess]
-elseif Compat.Sys.iswindows()
-    defaults = [Binaries,PackageManager,SystemPaths]
+defaults = if build_source[] == "always"
+    [BuildProcess]
 else
-    defaults = [SystemPaths,BuildProcess]
+    d = if Compat.Sys.isapple()
+        [Binaries, PackageManager, SystemPaths, BuildProcess]
+    elseif Compat.Sys.islinux() || Compat.Sys.isbsd()
+        [PackageManager, SystemPaths, Binaries, BuildProcess]
+    elseif Compat.Sys.iswindows()
+        [Binaries, PackageManager, SystemPaths]
+    else
+        [SystemPaths, BuildProcess]
+    end
+    if build_source[] in ["never", "prefer"]
+        # Remove BuildProcess
+        for (i, p) in enumerate(d)
+            p == BuildProcess && deleteat!(d, i)
+        end
+    end
+    if build_source[] == "prefer"
+        # Put it back in front
+        unshift!(d, BuildProcess)
+    end
+    d
 end
 
 function applicable(dep::LibraryDependency)


### PR DESCRIPTION
This introduces two new environment variables: `JULIA_BINDEPS_USE_SUDO` and `JULIA_BINDEPS_BUILD_SOURCE`. The former can be used to avoid checking `sudo -V` and automatically enable or disable `sudo`. The latter allows the user to set their preference for how/when to build from source. See the additions to the README for a more thorough explanation.

`JULIA_BINDEPS_BUILD_SOURCE` provides a solution to #328, and `JULIA_BINDEPS_USE_SUDO` is essentially #325.