### PR TITLE
>1.0/1.1 changes preventing `BinDeps.debug()`

### DIFF
--- a/src/BinDeps.jl
+++ b/src/BinDeps.jl
@@ -554,11 +554,11 @@ autotools_install(args...) = error("autotools_install has been removed")
 function eval_anon_module(context, file)
     m = Module(:__anon__)
     if isdefined(Base, Symbol("@__MODULE__"))
-        eval(m, :(ARGS=[$context]))
+        Base.eval(m, :(ARGS=[$context]))
         Base.include(m, file)
     else
         body = Expr(:toplevel, :(ARGS=[$context]), :(include($file)))
-        eval(m, body)
+        Base.eval(m, body)
     end
     return
 end

--- a/src/BinDeps.jl
+++ b/src/BinDeps.jl
@@ -231,7 +231,7 @@ function run(c::Choices)
                     return run(x.step)
                 end
             end
-            Compat.@warn("Invalid method")
+            @warn "Invalid method"
         end
     end
 end

--- a/src/debug.jl
+++ b/src/debug.jl
@@ -66,4 +66,4 @@ function debug(io,pkg::AbstractString)
         show($io,dep)
     end
 end
-debug(pkg::AbstractString) = debug(STDOUT,pkg)
+debug(pkg::AbstractString) = debug(stdout,pkg)

--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -964,7 +964,7 @@ macro install(_libmaps...)
             end
         end)
     else
-        libmaps = eval(_libmaps[1])
+        libmaps = Base.eval(_libmaps[1])
         load_cache = gensym()
         ret = Expr(:block)
         push!(ret.args,
@@ -1080,7 +1080,7 @@ macro load_dependencies(args...)
     file = "../deps/build.jl"
     if length(args) == 1
         if isa(args[1],Expr)
-            arg1 = eval(args[1])
+            arg1 = Base.eval(args[1])
         elseif typeof(args[1]) <: AbstractString
             file = args[1]
             dir = dirname(normpath(joinpath(dirname(file),"..")))
@@ -1091,7 +1091,7 @@ macro load_dependencies(args...)
         end
     elseif length(args) == 2
         file = args[1]
-        arg1 = typeof(args[2]) <: AbstractDict || isa(args[2],Vector) ? args[2] : eval(args[2])
+        arg1 = typeof(args[2]) <: AbstractDict || isa(args[2],Vector) ? args[2] : Base.eval(args[2])
     elseif length(args) != 0
         error("No version of @load_dependencies takes $(length(args)) arguments. See usage instructions!")
     end

--- a/src/dependencies.jl
+++ b/src/dependencies.jl
@@ -136,7 +136,7 @@ end
 function available_version(p::AptGet)
     vers = available_versions(p)
     isempty(vers) && error("apt-cache did not return version information. This shouldn't happen. Please file a bug!")
-    length(vers) > 1 && warn("Multiple versions of $(p.package) are available.  Use BinDeps.available_versions to get all versions.")
+    length(vers) > 1 && @warn "Multiple versions of $(p.package) are available.  Use BinDeps.available_versions to get all versions."
     return vers[end]
 end
 pkg_name(a::AptGet) = a.package
@@ -731,11 +731,11 @@ function check_system_handle!(ret,dep,handle)
                     return
                 end
             catch
-                warn("""
+                @warn """
                     Found a library that does not exist.
                     This may happen if the library has an active open handle.
                     Please quit julia and try again.
-                    """)
+                    """
                 return
             end
         end
@@ -1043,7 +1043,7 @@ macro install(_libmaps...)
                     end
                 end))
         if !(typeof(libmaps) <: AbstractDict)
-            warn("Incorrect mapping in BinDeps.@install call. No dependencies will be cached.")
+            @warn "Incorrect mapping in BinDeps.@install call. No dependencies will be cached."
         end
         ret
     end


### PR DESCRIPTION
Currently `BinDeps.debug()` fails due to this