### PR TITLE
Allow newer Cairo versions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BinDeps"
 uuid = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
-version = "1.0.1"
+version = "1.0.2"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -10,7 +10,7 @@ URIParser = "30578b45-9adc-5946-b283-645ec420af67"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
-Cairo = "0.5, 0.6"
+Cairo = "0.5, 0.6, 0.7, 0.8, 0.9, 1.0"
 URIParser = "0.3.1, 0.4"
 julia = "1"
 


### PR DESCRIPTION
At Gadfly, this package seems to be causing unsatisfiable requirements on Julia 1.0 (https://github.com/GiovineItalia/Gadfly.jl/runs/1407539026). With this pull request, I hope to solve that problem.